### PR TITLE
Submit/go to next step when pressing enter in form.

### DIFF
--- a/src/components/NavForm.jsx
+++ b/src/components/NavForm.jsx
@@ -37,11 +37,12 @@ const originalNextPage = Wizard.prototype.nextPage;
 Wizard.prototype.nextPage = function () {
   return originalNextPage.call(this).catch((error) => {
     const errorList = document.querySelector("div[id^='error-list-']");
+    const firstError = document.querySelector("div[id^='error-list-'] li:first-of-type");
     errorList.scrollIntoView({
       behavior: "smooth",
       block: "center",
     });
-    errorList.focus({ preventScroll: true });
+    firstError.focus({ preventScroll: true });
     return Promise.reject(error);
   });
 };

--- a/template/src/templates/navdesign/wizard/form.ejs
+++ b/template/src/templates/navdesign/wizard/form.ejs
@@ -4,7 +4,7 @@
     <h2 class="typo-innholdstittel">{{ctx.panels[ctx.currentPage].title}}</h2>
     <form class="wizard-page" ref="{{ctx.wizardKey}}">
       {{ctx.components}}
+      {{ ctx.wizardNav }}
     </form>
-    {{ ctx.wizardNav }}
   </div>
 </div>

--- a/template/src/templates/navdesign/wizardNav/form.ejs
+++ b/template/src/templates/navdesign/wizardNav/form.ejs
@@ -1,22 +1,22 @@
 <nav class="list-inline" id="{{ ctx.wizardKey }}-nav">
   {% if (ctx.buttons.cancel) { %}
   <div class="list-inline-item">
-    <button class="btn btn-secondary btn-wizard-nav-cancel" ref="{{ctx.wizardKey}}-cancel">{{ctx.t('cancel')}}</button>
+    <button class="btn btn-secondary btn-wizard-nav-cancel" type="button" ref="{{ctx.wizardKey}}-cancel">{{ctx.t('cancel')}}</button>
   </div>
   {% } %}
   {% if (ctx.buttons.previous) { %}
   <div class="list-inline-item">
-    <button class="btn btn-primary btn-wizard-nav-previous" ref="{{ctx.wizardKey}}-previous">{{ctx.t('previous')}}</button>
+    <button class="btn btn-primary btn-wizard-nav-previous" type="button" ref="{{ctx.wizardKey}}-previous">{{ctx.t('previous')}}</button>
   </div>
   {% } %}
   {% if (ctx.buttons.next) { %}
   <div class="list-inline-item">
-    <button class="btn btn-primary btn-wizard-nav-next" ref="{{ctx.wizardKey}}-next">{{ctx.t('next')}}</button>
+    <button class="btn btn-primary btn-wizard-nav-next" type="submit" ref="{{ctx.wizardKey}}-next">{{ctx.t('next')}}</button>
   </div>
   {% } %}
   {% if (ctx.buttons.submit) { %}
   <div class="list-inline-item">
-    <button class="btn btn-primary btn-wizard-nav-submit" ref="{{ctx.wizardKey}}-submit">{{ctx.t('submit')}}</button>
+    <button class="btn btn-primary btn-wizard-nav-submit" type="submit" ref="{{ctx.wizardKey}}-submit">{{ctx.t('submit')}}</button>
   </div>
   {% } %}
 </nav>


### PR DESCRIPTION
This will push the buttons into the blue frame around forms, which is not ideal, but required to get this to work for now.
Adding form-attribute to buttons outside of the form does not work, as form.io seem to filter that attribute away.
Adding a div inside the form for styling, but around the components somehow breaks validation, so that was not an option either.