### PR TITLE
Only add the required attribute to inputs if the component specifies it.

### DIFF
--- a/template/src/templates/navdesign/input/form.ejs
+++ b/template/src/templates/navdesign/input/form.ejs
@@ -16,7 +16,9 @@
   {{attr}}="{{ctx.input.attr[attr]}}"
   {% } %}
   id="{{ctx.component.key}}"
-  required="{{ctx.component.validate.required}}"
+  {% if (ctx.component.validate.required) { %}
+    required="{{ctx.component.validate.required}}"
+  {% } %}
   aria-describedby="{{ctx.component.key}}-error"
 >{{ctx.input.content}}</{{ctx.input.type}}>
 {% } %}


### PR DESCRIPTION
The field is announced as required as long as the attribute exists, even with the value "false" or no value.