### PR TITLE
Lock bootstrap version to avoid incorrect styling for Belop component

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -21,6 +21,9 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.17.0'
       - name: Cache node modules
         id: cache-node-modules
         uses: actions/cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:14.17.0-alpine
 ENV NODE_ENV production
 
 WORKDIR usr/src/app/server

--- a/package-lock.json
+++ b/package-lock.json
@@ -3480,9 +3480,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bootstrap": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.1.tgz",
-      "integrity": "sha512-bxUooHBSbvefnIZfjD0LE8nfdPKrtiFy2sgrxQwUZ0UpFzpjVbVMUxaGIoo9XWT4B2LG1HX6UQg0UMOakT0prQ=="
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.4.1.tgz",
+      "integrity": "sha512-tbx5cHubwE6e2ZG7nqM3g/FZ5PQEDMWmMGNrCUBVRPHXTJaH7CBDdsLeu3eCh3B1tzAxTnAbtmrzvWEvT2NNEA=="
     },
     "boxen": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@sentry/browser": "^5.27.0",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
-    "bootstrap": "^4.4.1",
+    "bootstrap": "4.4.1",
     "classnames": "^2.2.6",
     "craco-less": "^1.16.0",
     "cross-env": "^7.0.2",


### PR DESCRIPTION
Bootstrap was only limited to major version 4, meaning minor version can change.
We use 4.4.1 (locked) in byggeren, but got 4.5.1 in utfylleren because of npm dependency version resolution.
As a result, a CSS change in 4.5.x caused the input for inputs with postfix or suffix to have 1% width.
Hard-coding the bootstrap version for now to avoid this.

Will remove Bootstrap as soon as possible to avoid shit like this from happening, as we really don't need or want bootstrap.