### PR TITLE
Update slack webhook for dev

### DIFF
--- a/.github/workflows/deploy-fyllut.yaml
+++ b/.github/workflows/deploy-fyllut.yaml
@@ -142,6 +142,6 @@ jobs:
       - name: "Slack notification"
         uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEV }}
           SLACK_FOOTER: "Deploy av fyllut til dev har feilet. Undersøk om det kan påvirke neste publisering fra byggeren."
           SLACK_COLOR: "#ff9100"


### PR DESCRIPTION
Updated these with new webhooks for #team-fyllut-sendinn-alerts and #team-fyllut-sendinn-alerts-dev
<img width="763" alt="Skjermbilde 2023-10-23 kl  12 40 55" src="https://github.com/navikt/skjemautfylling-formio/assets/7783861/89154086-95da-4274-b398-1ed3f5b30814">

Also changed the name of the bot from `Team skjemadigitalisering` to `Team Fyllut - Sendinn`
